### PR TITLE
Add some of the recent changes to various GPU specific help docs.

### DIFF
--- a/gpu.rst
+++ b/gpu.rst
@@ -3,17 +3,23 @@ GPU Processing
 
 The cluster contains three nodes with **Nvidia GPU** co-processors to accelerate CPUs for general-purpose scientific and engineering computing.
 
-- ``jaws`` contains a single Tesla V100 card with 16 GB of dedicated GPU memory
-- ``thanos`` contains dual Tesla V100 cards, each with 32 GB of dedicated GPU memory
-- ``twiki`` contains dual Quadro RTX 8000 cards, each with 48 GB of dedicated GPU memory
-- ``pigwidgeon`` ``nagini`` contain quad Ampere A100 cards, each with 80 GB of dedicated GPU memory
+- ``aragog`` ``buckbeak`` ``crookshanks`` ``dobby`` ``fawkes`` ``hedwig`` `` peeves`` ``pigwidgeon`` ``nagini`` contain quad Ampere A100 cards, each with 80 GB of dedicated GPU memory
+- ``angel`` ``anya`` ``darla`` ``drusilla`` ``lorne`` ``spike`` contain dual L40S cards, each with 48GB of dedicated GPU memory
+- ``thanos`` contains dual Tesla V100 cards, each with 32 GB of dedicated GPU memory (only available via himem queue)
+- ``jaws`` contains a single Tesla V100 card with 16 GB of dedicated GPU memory (currently unavailable)
+- ``twiki`` contains dual Quadro RTX 8000 cards, each with 48 GB of dedicated GPU memory (currently unavailable)
 
 .. warning::
-  As of June 2023 ``thanos`` is no longer part of the ``gpu`` queue but its GPUs remain accessible for now.
+  As of June 2023 ``thanos`` is no longer part of the ``gpu`` queue but its GPUs remain accessible for now. The ``jaws`` and ``twiki`` nodes are currently not available.
 
-The Tesla cards each have 5,120 **CUDA** processing cores and 640 **Tensor** cores. The RTX cards have 4,608 **CUDA** processing cores and 576 **Tensor** cores. The Ampere cards each have 6,912 **CUDA** processing cores and 432 **Tensor** cores. CUDA is Nvidia's parallel computing platform and API for general GPU processing, whereas Tensor cores are specifically intended to speed up the training of neural networks.
+The Ampere cards each have 6,912 **CUDA** processing cores and 432 **Tensor** cores. 
+The L40S cards each have 18,176 **CUDA** processing cores and 568 **Tensor** cores.
+The Tesla cards each have 5,120 **CUDA** processing cores and 640 **Tensor** cores. 
+The RTX cards have 4,608 **CUDA** processing cores and 576 **Tensor** cores. 
 
-More information about the cards is available at https://www.nvidia.com/en-gb/data-center/tesla-v100/, https://www.nvidia.com/en-gb/design-visualization/quadro/rtx-8000/, and https://www.nvidia.com/en-us/data-center/a100/.
+CUDA is Nvidia's parallel computing platform and API for general GPU processing, whereas Tensor cores are specifically intended to speed up the training of neural networks.
+
+More information about the cards is available at https://www.nvidia.com/en-us/data-center/a100/, https://www.nvidia.com/en-gb/data-center/l40s/ https://www.nvidia.com/en-gb/data-center/tesla-v100/, and https://www.nvidia.com/en-gb/design-visualization/quadro/rtx-8000/.
 
 To access the GPUs, you must both submit to the ``gpu`` Slurm partition and specify how many GPUs you require. For example, to run a basic interactive job::
 

--- a/gpu.rst
+++ b/gpu.rst
@@ -5,12 +5,11 @@ The cluster contains three nodes with **Nvidia GPU** co-processors to accelerate
 
 - ``aragog`` ``buckbeak`` ``crookshanks`` ``dobby`` ``fawkes`` ``hedwig`` ``peeves`` ``pigwidgeon`` and ``nagini`` contain quad Ampere A100 cards, each with 80 GB of dedicated GPU memory
 - ``angel`` ``anya`` ``darla`` ``drusilla`` ``lorne`` and ``spike`` contain dual L40S cards, each with 48GB of dedicated GPU memory
-- ``thanos`` contains dual Tesla V100 cards, each with 32 GB of dedicated GPU memory (only available via himem queue)
 - ``jaws`` contains a single Tesla V100 card with 16 GB of dedicated GPU memory (currently unavailable)
 - ``twiki`` contains dual Quadro RTX 8000 cards, each with 48 GB of dedicated GPU memory (currently unavailable)
 
 .. warning::
-  As of June 2023 ``thanos`` is no longer part of the ``gpu`` queue but its GPUs remain accessible for now. The ``jaws`` and ``twiki`` nodes are currently not available.
+  The ``jaws`` and ``twiki`` nodes are currently not available.
 
 The Ampere cards each have 6,912 **CUDA** processing cores and 432 **Tensor** cores. 
 The L40S cards each have 18,176 **CUDA** processing cores and 568 **Tensor** cores.

--- a/gpu.rst
+++ b/gpu.rst
@@ -3,8 +3,8 @@ GPU Processing
 
 The cluster contains three nodes with **Nvidia GPU** co-processors to accelerate CPUs for general-purpose scientific and engineering computing.
 
-- ``aragog`` ``buckbeak`` ``crookshanks`` ``dobby`` ``fawkes`` ``hedwig`` `` peeves`` ``pigwidgeon`` ``nagini`` contain quad Ampere A100 cards, each with 80 GB of dedicated GPU memory
-- ``angel`` ``anya`` ``darla`` ``drusilla`` ``lorne`` ``spike`` contain dual L40S cards, each with 48GB of dedicated GPU memory
+- ``aragog`` ``buckbeak`` ``crookshanks`` ``dobby`` ``fawkes`` ``hedwig`` ``peeves`` ``pigwidgeon`` and ``nagini`` contain quad Ampere A100 cards, each with 80 GB of dedicated GPU memory
+- ``angel`` ``anya`` ``darla`` ``drusilla`` ``lorne`` and ``spike`` contain dual L40S cards, each with 48GB of dedicated GPU memory
 - ``thanos`` contains dual Tesla V100 cards, each with 32 GB of dedicated GPU memory (only available via himem queue)
 - ``jaws`` contains a single Tesla V100 card with 16 GB of dedicated GPU memory (currently unavailable)
 - ``twiki`` contains dual Quadro RTX 8000 cards, each with 48 GB of dedicated GPU memory (currently unavailable)

--- a/machine-learning.rst
+++ b/machine-learning.rst
@@ -2,9 +2,8 @@ Machine Learning
 ================
 
 This page explains how to set up the tensorflow python module for accelerating machine learning using the
-GPUs installed on nodes in the GPU partition and ``thanos`` in the himem partition. If you have other 
-software you prefer to use for machine learning you are free to 
-try it out instead, but this page uses tensorflow as an example.
+GPUs installed on nodes in the GPU partition. If you have other software you prefer to use for machine 
+learning you are free to try it out instead, but this page uses tensorflow as an example.
 
 Begin by logging in to the HPC onto the ``gruffalo`` server as normal.
 

--- a/machine-learning.rst
+++ b/machine-learning.rst
@@ -2,8 +2,8 @@ Machine Learning
 ================
 
 This page explains how to set up the tensorflow python module for accelerating machine learning using the
-GPUs installed in the ``pigwidgeon``, ``nagini``, ``twiki`` and ``jaws`` nodes in the GPU partition and ``thanos`` 
-in the himem partition. If you have other software you prefer to use for machine learning you are free to 
+GPUs installed on nodes in the GPU partition and ``thanos`` in the himem partition. If you have other 
+software you prefer to use for machine learning you are free to 
 try it out instead, but this page uses tensorflow as an example.
 
 Begin by logging in to the HPC onto the ``gruffalo`` server as normal.

--- a/slurm-overview.rst
+++ b/slurm-overview.rst
@@ -217,7 +217,7 @@ We passed no extra parameters, meaning the job only has access to a single CPU, 
 GPU resources
 ~~~~~~~~~~~~~
 
-The ``gpu`` queue must be used to access a GPU, which are available on the ``thanos`` node (and later on ``jaws`` once setup). Select the ``gpu`` queue and use the --gpus option to request one or both of the available GPUs. See :doc:`gpu` for details.
+The ``gpu`` queue must be used to access a GPU. Select the ``gpu`` queue and use the --gpus option to request one or both of the available GPUs. See :doc:`gpu` for details.
 
 
 Cancelling a job


### PR DESCRIPTION
Add specific GPU info to various doc pages to specify the new hardware of the GPU queue after Dec 2024 upgrades.